### PR TITLE
Add pass the second parameter 'next state' for rule code

### DIFF
--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,4 +1,4 @@
-#!perl -w
+#!/usr/bin/perl -w
 
 use strict;
 use Test::More;

--- a/t/pod-spelling.t
+++ b/t/pod-spelling.t
@@ -1,4 +1,4 @@
-#!perl -w
+#!/usr/bin/perl -w
 
 use strict;
 use Test::More;


### PR DESCRIPTION
Pass the second parameter 'next state' for rule code, when called from 'try_switch' or 'switch'.
Fix path to perl in pod-*.t

---- 1 test not passed
t/pod-spelling.t .. 1/1
# Failed test 'POD spelling for blib/lib/FSA/Rules.pm'
# at /usr/share/perl5/Test/Spelling.pm line 80.
# Errors:
# GitHub
# Looks like you failed 1 test of 1.

t/pod-spelling.t .. Dubious, test returned 1 (wstat 256, 0x100)
## Failed 1/1 subtests

I do not understand how to fix it.
